### PR TITLE
Update CNAME to destruct.tk

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-destructhub.tk
+destruct.tk


### PR DESCRIPTION
I just lost the destructhub.tk domain for free. Sad. destruct.tk, by another hand, is more compact.