### PR TITLE
Remove CNAME because domain destruct.tk is lost

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-destruct.tk


### PR DESCRIPTION
That means: clicking in destructhub.github.io link will redirect to a
wrong page.

This PR fixes this behavior.